### PR TITLE
update iOS version to latest sdk

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,7 @@ repositories {
 }
 
 dependencies {
-    implementation ('org.jitsi.react:jitsi-meet-sdk:2.9.0') {
+    implementation ('org.jitsi.react:jitsi-meet-sdk:+') {
       transitive = true
     }
 }

--- a/react-native-jitsi-meet.podspec
+++ b/react-native-jitsi-meet.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'JitsiMeetSDK', '2.9.0'
+  s.dependency 'JitsiMeetSDK'
 end


### PR DESCRIPTION
Current latest iOS version is 2.10.2 

This fixes the bug of not dismissing the active video call icon, when a call is terminated.