### PR TITLE
Set android JitsiMeetSdk to 2.10.0 version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,10 +11,10 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION = 26
-def DEFAULT_BUILD_TOOLS_VERSION = "27.0.3"
-def DEFAULT_TARGET_SDK_VERSION  = 29
+def DEFAULT_BUILD_TOOLS_VERSION = "29.0.2"
 def DEFAULT_MIN_SDK_VERSION     = 23
+def DEFAULT_COMPILE_SDK_VERSION = 29
+def DEFAULT_TARGET_SDK_VERSION  = 29
 
 android {
   compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,8 +13,8 @@ apply plugin: 'com.android.library'
 
 def DEFAULT_COMPILE_SDK_VERSION = 26
 def DEFAULT_BUILD_TOOLS_VERSION = "27.0.3"
-def DEFAULT_TARGET_SDK_VERSION  = 22
-def DEFAULT_MIN_SDK_VERSION     = 17
+def DEFAULT_TARGET_SDK_VERSION  = 29
+def DEFAULT_MIN_SDK_VERSION     = 23
 
 android {
   compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
@@ -45,7 +45,7 @@ repositories {
 }
 
 dependencies {
-    implementation ('org.jitsi.react:jitsi-meet-sdk:+') {
+    implementation ('org.jitsi.react:jitsi-meet-sdk:2.10.0') {
       transitive = true
     }
 }


### PR DESCRIPTION
Works on android as expected. Change default config versions of build, compile, target.