### PR TITLE
Version 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,78 @@
 # react-native-jitsi-meet
 React native wrapper for Jitsi Meet SDK. Current version uses jitsi-meet v3.6.0
 
-## Install
+## Install in your project
 
-`npm install react-native-jitsi-meet --save` 
+```shell
+npm install git+https://github.com/moirognwmonio/react-native-jitsi-meet.git#v3.6.0-dev --save
+cd ios && pod install
+```
+
+### Artifacts that this library uses
+
+#### iOS
+
+- The artifacts to use are: [jitsi-meet-ios-sdk-releases](https://github.com/softhouse-gr/jitsi-meet-ios-sdk-releases).
+- On this library you just need to specify the jitsi-meet-sdk version that was used to create the aformentioned artifacts.
+- This can be done in the react-native-jitsi-meet.podspec file at line 19
+- After that in your project's Podfile you need to add at the end of the file the following line:
+
+```
+pod 'JitsiMeetSDK', :git => 'https://github.com/softhouse-gr/jitsi-meet-ios-sdk-releases.git', :tag => 'v1.0.5-dev'
+```
+
+The above line overides the official pod of JitsiMeetSDK with your custom one.
+
+### Android
+
+- The artifacts to use are: [jitsi-maven-repository](https://github.com/softhouse-gr/jitsi-maven-repository).
+- On this library you need to specify the maven url in the /android/build.gradle, and the jitsi-meet-sdk version that was used to build them, file like this:
+
+```
+repositories {
+  maven {
+      url "https://github.com/softhouse-gr/jitsi-maven-repository/raw/main/releases"
+  }
+  google()
+  mavenCentral()
+  jcenter()
+}
+
+dependencies {
+    implementation ('org.jitsi.react:jitsi-meet-sdk:3.7.0') {
+    // You can exclude the libraries you may use in your project here to prevent duplicates
+    //   exclude group: 'com.facebook.react', module: 'react-native-background-timer'
+    //   exclude group: 'com.facebook.react', module: 'react-native-webview'
+    //   exclude group: 'com.facebook.react', module: 'react-native-async-storage'
+    //   exclude group: 'com.facebook.react', module: 'react-native-community_netinfo'
+    //   exclude group: 'com.facebook.react', module: 'react-native-device-info'
+    //   exclude group: 'com.facebook', module: 'hermes'
+      transitive = true
+    }
+}
+```
+
+- After that, in your project at android/build.gradle you must add the following:
+```shell
+allprojects {
+    repositories {
+        ...
+        maven {
+            // Custom jitsi meet sdk
+            url "https://github.com/softhouse-gr/jitsi-maven-repository/raw/main/releases"
+            // Original library
+            // url "https://github.com/jitsi/jitsi-maven-repository/raw/master/releases"
+        }
+        ...
+   }
+}
+```
+
+## [Jitsi Meet](https://github.com/moirognwmonio/jitsi-meet)
+
+- The source project jitsi-meet can be found [here](https://github.com/moirognwmonio/jitsi-meet), which contains all the docs that you wll need to create your custom artifacts.
+
+## Original readme
 
 If you are using React-Native < 0.60, you should use a version < 2.0.0.  
 For versions higher than 2.0.0, you need to add the following piece of code in your ```metro.config.js``` file to avoid conflicts between react-native-jitsi-meet and react-native in metro bundler.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ React native wrapper for Jitsi Meet SDK. Current version uses jitsi-meet v3.6.0
 ## Install in your project
 
 ```shell
-npm install git+https://github.com/moirognwmonio/react-native-jitsi-meet.git#v3.6.0-dev --save
+yarn add git+https://github.com/moirognwmonio/react-native-jitsi-meet.git#v3.6.0
 cd ios && pod install
 ```
 
@@ -18,7 +18,7 @@ cd ios && pod install
 - After that in your project's Podfile you need to add at the end of the file the following line:
 
 ```
-pod 'JitsiMeetSDK', :git => 'https://github.com/softhouse-gr/jitsi-meet-ios-sdk-releases.git', :tag => 'v1.0.5-dev'
+pod 'JitsiMeetSDK', :git => 'https://github.com/softhouse-gr/jitsi-meet-ios-sdk-releases.git', :tag => 'v3.6.0'
 ```
 
 The above line overrides the official pod of JitsiMeetSDK with your custom one.
@@ -40,13 +40,13 @@ repositories {
 
 dependencies {
     implementation ('org.jitsi.react:jitsi-meet-sdk:3.6.0') {
-    // You can exclude the libraries you may use in your project here to prevent duplicates
-    //   exclude group: 'com.facebook.react', module: 'react-native-background-timer'
-    //   exclude group: 'com.facebook.react', module: 'react-native-webview'
-    //   exclude group: 'com.facebook.react', module: 'react-native-async-storage'
-    //   exclude group: 'com.facebook.react', module: 'react-native-community_netinfo'
-    //   exclude group: 'com.facebook.react', module: 'react-native-device-info'
-    //   exclude group: 'com.facebook', module: 'hermes'
+      // You can exclude the libraries you may use in your project here to prevent duplicates
+      // exclude group: 'com.facebook.react', module: 'react-native-background-timer'
+      // exclude group: 'com.facebook.react', module: 'react-native-webview'
+      // exclude group: 'com.facebook.react', module: 'react-native-async-storage'
+      // exclude group: 'com.facebook.react', module: 'react-native-community_netinfo'
+      // exclude group: 'com.facebook.react', module: 'react-native-device-info'
+      // exclude group: 'com.facebook', module: 'hermes'
       transitive = true
     }
 }
@@ -97,6 +97,7 @@ allprojects {
 - but buttons on android will not work because of [that](https://github.com/jitsi/jitsi-meet/issues/8948#issuecomment-856566676).
 - A solution could be to fork the custom react-native from jitsi meet
 - and make the necessary changes [here](https://github.com/jitsi/react-native/blob/891986ec5ecaef65d1c8a7fe472f86cf84fe7551/Libraries/Components/Touchable/Touchable.js#L888) to fix the android error.
+- You could also update the react-native version of jitsi-meet to > v0.63.4 which fixes the error.
 - A quicker solution but not recommended,
 - is the change of Touchable.js in the node_modules to use the SoundManager library for the playTouchSound function,
 - as indicated [here](https://github.com/facebook/react-native/commit/9dbe5e241e3137196102fb808c181c57554fedfe).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cd ios && pod install
 #### iOS
 
 - The artifacts to use are: [jitsi-meet-ios-sdk-releases](https://github.com/softhouse-gr/jitsi-meet-ios-sdk-releases).
-- On this library you just need to specify the jitsi-meet-sdk version that was used to create the aformentioned artifacts.
+- On this library you just need to specify the jitsi-meet-sdk version that was used to create the aforementioned artifacts.
 - This can be done in the react-native-jitsi-meet.podspec file at line 19
 - After that in your project's Podfile you need to add at the end of the file the following line:
 
@@ -21,7 +21,7 @@ cd ios && pod install
 pod 'JitsiMeetSDK', :git => 'https://github.com/softhouse-gr/jitsi-meet-ios-sdk-releases.git', :tag => 'v1.0.5-dev'
 ```
 
-The above line overides the official pod of JitsiMeetSDK with your custom one.
+The above line overrides the official pod of JitsiMeetSDK with your custom one.
 
 ### Android
 
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-    implementation ('org.jitsi.react:jitsi-meet-sdk:3.7.0') {
+    implementation ('org.jitsi.react:jitsi-meet-sdk:3.6.0') {
     // You can exclude the libraries you may use in your project here to prevent duplicates
     //   exclude group: 'com.facebook.react', module: 'react-native-background-timer'
     //   exclude group: 'com.facebook.react', module: 'react-native-webview'
@@ -57,16 +57,50 @@ dependencies {
 allprojects {
     repositories {
         ...
+        mavenLocal()
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url("$rootDir/../node_modules/react-native/android")
+        }
+
         maven {
             // Custom jitsi meet sdk
             url "https://github.com/softhouse-gr/jitsi-maven-repository/raw/main/releases"
-            // Original library
-            // url "https://github.com/jitsi/jitsi-maven-repository/raw/master/releases"
+
+            // Used for Vsale <= v2.0.6
+            // url "https://github.com/softhouse-gr/jitsi-meet/raw/master/repo"
         }
+
+        maven {
+            // Android JSC is installed from npm
+            url("$rootDir/../node_modules/jsc-android/dist")
+        }
+
+        google()
+        jcenter()
+        maven { url 'https://www.jitpack.io' }
         ...
    }
 }
 ```
+
+# Notes
+
+1) (**RN**) Building jitsi-meet
+- Build from jitsi-meet >= v4.0.0 would cause a launch error,
+- because we are using reanimated library >= v2.0.0,
+- but jitsi-meet is using a version < v2.0.0,
+- which is incompatible.
+
+2) (**ANDROID**) Building jitsi-meet 
+- from android-sdk-3.6.0 tag will have as a result a successful launch of the app
+- but buttons on android will not work because of [that](https://github.com/jitsi/jitsi-meet/issues/8948#issuecomment-856566676).
+- A solution could be to fork the custom react-native from jitsi meet
+- and make the necessary changes [here](https://github.com/jitsi/react-native/blob/891986ec5ecaef65d1c8a7fe472f86cf84fe7551/Libraries/Components/Touchable/Touchable.js#L888) to fix the android error.
+- A quicker solution but not recommended,
+- is the change of Touchable.js in the node_modules to use the SoundManager library for the playTouchSound function,
+- as indicated [here](https://github.com/facebook/react-native/commit/9dbe5e241e3137196102fb808c181c57554fedfe).
+- Obviously, this should be done every time you reinstall your packages in jitsi-meet because you changed the node_modules. 
 
 ## [Jitsi Meet](https://github.com/moirognwmonio/jitsi-meet)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # react-native-jitsi-meet
-React native wrapper for Jitsi Meet SDK
+React native wrapper for Jitsi Meet SDK. Current version uses jitsi-meet v3.6.0
 
 ## Install
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
 
 repositories {
   maven {
-      url "https://github.com/moirognwmonio/jitsi-meet/raw/feature/custom-waiting-dialog/android-repo"
+      url "https://github.com/softhouse-gr/jitsi-maven-repository/raw/main/releases"
   }
   google()
   mavenCentral()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
 
 repositories {
   maven {
-      url "https://github.com/softhouse-gr/jitsi-maven-repository/raw/android-sdk-3.6.0-rev-1/releases"
+      url "https://github.com/softhouse-gr/jitsi-maven-repository/raw/main/releases"
   }
   google()
   mavenCentral()
@@ -46,13 +46,13 @@ repositories {
 
 dependencies {
     implementation ('org.jitsi.react:jitsi-meet-sdk:3.6.0') {
-    // You can exclude the libraries you may use in your project here to prevent duplicates
-    //   exclude group: 'com.facebook.react', module: 'react-native-background-timer'
-    //   exclude group: 'com.facebook.react', module: 'react-native-webview'
-    //   exclude group: 'com.facebook.react', module: 'react-native-async-storage'
-    //   exclude group: 'com.facebook.react', module: 'react-native-community_netinfo'
-    //   exclude group: 'com.facebook.react', module: 'react-native-device-info'
-    //   exclude group: 'com.facebook', module: 'hermes'
+      // You can exclude the libraries you may use in your project here to prevent duplicates
+      // exclude group: 'com.facebook.react', module: 'react-native-background-timer'
+      // exclude group: 'com.facebook.react', module: 'react-native-webview'
+      // exclude group: 'com.facebook.react', module: 'react-native-async-storage'
+      // exclude group: 'com.facebook.react', module: 'react-native-community_netinfo'
+      // exclude group: 'com.facebook.react', module: 'react-native-device-info'
+      // exclude group: 'com.facebook', module: 'hermes'
       transitive = true
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,8 +45,7 @@ repositories {
 }
 
 dependencies {
-    def jitsi_version = safeExtGet("jitsi_version", "3.7.0")
-    implementation ("org.jitsi.react:jitsi-meet-sdk:$jitsi_version") {
+    implementation ('org.jitsi.react:jitsi-meet-sdk:3.7.0') {
     // You can exclude the libraries you may use in your project here to prevent duplicates
     //   exclude group: 'com.facebook.react', module: 'react-native-background-timer'
     //   exclude group: 'com.facebook.react', module: 'react-native-webview'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
 
 repositories {
   maven {
-      url "https://github.com/softhouse-gr/jitsi-maven-repository/raw/main/releases"
+      url "https://github.com/softhouse-gr/jitsi-maven-repository/raw/android-sdk-3.6.0-rev-1/releases"
   }
   google()
   mavenCentral()
@@ -45,7 +45,7 @@ repositories {
 }
 
 dependencies {
-    implementation ('org.jitsi.react:jitsi-meet-sdk:3.7.0') {
+    implementation ('org.jitsi.react:jitsi-meet-sdk:3.6.0') {
     // You can exclude the libraries you may use in your project here to prevent duplicates
     //   exclude group: 'com.facebook.react', module: 'react-native-background-timer'
     //   exclude group: 'com.facebook.react', module: 'react-native-webview'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
 
 repositories {
   maven {
-      url "https://github.com/jitsi/jitsi-maven-repository/raw/master/releases"
+      url "https://github.com/moirognwmonio/jitsi-meet/raw/feature/custom-waiting-dialog/android-repo"
   }
   google()
   mavenCentral()
@@ -45,7 +45,15 @@ repositories {
 }
 
 dependencies {
-    implementation ('org.jitsi.react:jitsi-meet-sdk:2.12.0') {
+    def jitsi_version = safeExtGet("jitsi_version", "3.7.0")
+    implementation ("org.jitsi.react:jitsi-meet-sdk:$jitsi_version") {
+    // You can exclude the libraries you may use in your project here to prevent duplicates
+    //   exclude group: 'com.facebook.react', module: 'react-native-background-timer'
+    //   exclude group: 'com.facebook.react', module: 'react-native-webview'
+    //   exclude group: 'com.facebook.react', module: 'react-native-async-storage'
+    //   exclude group: 'com.facebook.react', module: 'react-native-community_netinfo'
+    //   exclude group: 'com.facebook.react', module: 'react-native-device-info'
+    //   exclude group: 'com.facebook', module: 'hermes'
       transitive = true
     }
 }

--- a/ios/RNJitsiMeetView.h
+++ b/ios/RNJitsiMeetView.h
@@ -1,4 +1,4 @@
-#import <JitsiMeet/JitsiMeet.h>
+#import <JitsiMeetSDK/JitsiMeetSDK.h>
 
 #import <React/RCTComponent.h>
 

--- a/ios/RNJitsiMeetView.h
+++ b/ios/RNJitsiMeetView.h
@@ -1,4 +1,5 @@
 #import <JitsiMeetSDK/JitsiMeetSDK.h>
+//@import JitsiMeetSDK;
 
 #import <React/RCTComponent.h>
 

--- a/ios/RNJitsiMeetViewManager.h
+++ b/ios/RNJitsiMeetViewManager.h
@@ -1,5 +1,6 @@
 #import <React/RCTViewManager.h>
 #import <JitsiMeetSDK/JitsiMeetViewDelegate.h>
+//@import JitsiMeetSDK;
 
 @interface RNJitsiMeetViewManager : RCTViewManager <JitsiMeetViewDelegate>
 @end

--- a/ios/RNJitsiMeetViewManager.h
+++ b/ios/RNJitsiMeetViewManager.h
@@ -1,5 +1,5 @@
 #import <React/RCTViewManager.h>
-#import <JitsiMeet/JitsiMeetViewDelegate.h>
+#import <JitsiMeetSDK/JitsiMeetViewDelegate.h>
 
 @interface RNJitsiMeetViewManager : RCTViewManager <JitsiMeetViewDelegate>
 @end

--- a/ios/RNJitsiMeetViewManager.m
+++ b/ios/RNJitsiMeetViewManager.m
@@ -1,6 +1,6 @@
 #import "RNJitsiMeetViewManager.h"
 #import "RNJitsiMeetView.h"
-#import <JitsiMeet/JitsiMeetUserInfo.h>
+#import <JitsiMeetSDK/JitsiMeetUserInfo.h>
 
 @implementation RNJitsiMeetViewManager{
     RNJitsiMeetView *jitsiMeetView;

--- a/ios/RNJitsiMeetViewManager.m
+++ b/ios/RNJitsiMeetViewManager.m
@@ -49,6 +49,9 @@ RCT_EXPORT_METHOD(call:(NSString *)urlString userInfo:(NSDictionary *)userInfo :
             for (NSString *flag in disableFeatures) {
                 [builder setFeatureFlag:flag withBoolean:NO];
             }
+
+            // [builder setFeatureFlag:@"pip.enabled" withBoolean:NO];
+            // [builder setFeatureFlag:@"calendar.enabled" withBoolean:NO];
         }];
 
         [jitsiMeetView join:options];
@@ -76,10 +79,14 @@ RCT_EXPORT_METHOD(audioCall:(NSString *)urlString userInfo:(NSDictionary *)userI
             builder.room = urlString;
             builder.userInfo = _userInfo;
             builder.audioOnly = true;
+            // builder.audioOnly = YES;
 
             for (NSString *flag in disableFeatures) {
                 [builder setFeatureFlag:flag withBoolean:NO];
             }
+
+            //[builder setFeatureFlag:@"pip.enabled" withBoolean:NO];
+            //[builder setFeatureFlag:@"calendar.enabled" withBoolean:NO];
         }];
 
         [jitsiMeetView join:options];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-jitsi-meet",
   "description": "Jitsi Meet SDK wrapper for React Native.",
-  "version": "1.3.3",
+  "version": "3.6.0",
   "forked_version": "2.1.1",
   "author": {
     "name": "Sébastien Krafft",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-jitsi-meet",
   "description": "Jitsi Meet SDK wrapper for React Native.",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "forked_version": "2.1.1",
   "author": {
     "name": "Sébastien Krafft",

--- a/react-native-jitsi-meet.podspec
+++ b/react-native-jitsi-meet.podspec
@@ -10,11 +10,11 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, "9.0"
+  s.platform     = :ios, "11.0"
 
   s.source       = { :git => "https://github.com/moirognwmonio/react-native-jitsi-meet.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'JitsiMeetSDK', '2.11.0'
+  s.dependency 'JitsiMeetSDK', '3.6.0'
 end


### PR DESCRIPTION
## Source information

- project: [jitsi-meet](https://github.com/moirognwmonio/jitsi-meet), branch: [sdk-3.6.0-mod](https://github.com/moirognwmonio/jitsi-meet/tree/sdk-3.6.0-mod)
- iOS: [jitsi-meet-ios-sdk-releases](https://github.com/softhouse-gr/jitsi-meet-ios-sdk-releases), tag v3.6.0
- Android: [jitsi-maven-repository](https://github.com/softhouse-gr/jitsi-maven-repository), tag v3.6.0


## Changelog

- Build from our jitsi-meet tag: sdk-3.6.0-mod
- Customize waiting dialog (fix iOS UI bug)
- Modified Podfile, in jitsi-meet project, to prevent application crash
- Hide more options button and it's contents
- Build for apps using react-native v0.64.2
- Package changes from official tag 'ios-sdk-3.6.0':

```shell
"react-native": "0.64.2",
"@react-native-community/netinfo": "5.0.0",
"hermes-engine": "0.7.2", // Currently not using hermes in our project
```
